### PR TITLE
convert grc severity to lowercase to avoid processing issues

### DIFF
--- a/pkg/processor/reportprocessor.go
+++ b/pkg/processor/reportprocessor.go
@@ -243,7 +243,7 @@ func getSevFromTemplate(plc unstructured.Unstructured, name string) string {
 	for _, template := range plcTemplates {
 		objDef := template.(map[string]interface{})["objectDefinition"].(map[string]interface{})
 		if objDef["metadata"].(map[string]interface{})["name"] == name {
-			return objDef["spec"].(map[string]interface{})["severity"].(string)
+			return strings.ToLower(objDef["spec"].(map[string]interface{})["severity"].(string))
 		}
 	}
 	return ""


### PR DESCRIPTION
Signed-off-by: Will Kutler <wkutler@redhat.com>

**Related Issue:**  https://github.com/stolostron/backlog/issues/19496

### Description of changes
currently, if a GRC policy has a severity with the first letter capitalized, total_risk will not be calculated properly. this change fixes the issue.
