### PR TITLE
convert grc sev to lower case

### DIFF
--- a/pkg/processor/reportprocessor.go
+++ b/pkg/processor/reportprocessor.go
@@ -243,7 +243,7 @@ func getSevFromTemplate(plc unstructured.Unstructured, name string) string {
 	for _, template := range plcTemplates {
 		objDef := template.(map[string]interface{})["objectDefinition"].(map[string]interface{})
 		if objDef["metadata"].(map[string]interface{})["name"] == name {
-			return objDef["spec"].(map[string]interface{})["severity"].(string)
+			return strings.ToLower(objDef["spec"].(map[string]interface{})["severity"].(string))
 		}
 	}
 	return ""


### PR DESCRIPTION
Signed-off-by: Will Kutler <wkutler@redhat.com>

**Related Issue:**  https://github.com/stolostron/backlog/issues/19496

### Description of changes
converts grc policy severity to lower case to avoid mapping issues if a user capitalizes the first letter of the severity
