### PR TITLE
process grc violations on non-openshift clusters

### DIFF
--- a/main.go
+++ b/main.go
@@ -66,7 +66,7 @@ func main() {
 	}
 
 	// Fetch the reports for each cluster & create the PolicyReport resources for each violation.
-	go ret.RetrieveCCXReport(hubID, fetchClusterIDs, fetchPolicyReports)
+	go ret.RetrieveCCXReport(hubID, fetchClusterIDs, fetchPolicyReports, monitor.ClusterNeedsCCX)
 
 	processor := processor.NewProcessor()
 	go processor.ProcessPolicyReports(fetchPolicyReports, dynamicClient)

--- a/pkg/monitor/clustermonitor_test.go
+++ b/pkg/monitor/clustermonitor_test.go
@@ -35,32 +35,79 @@ func Test_addCluster(t *testing.T) {
 	unmarshalFile("managed-cluster.json", &managedCluster, t)
 	monitor.addCluster(&managedCluster)
 
-	assert.Equal(t, types.ManagedClusterInfo{Namespace: "managed-cluster", ClusterID: "323a00cd-428a-49fb-80ab-201d2a5d3050"}, monitor.ManagedClusterInfo[0], "Test Add ManagedCluster: local-cluster")
+	assert.Equal(t, types.ManagedClusterInfo{Namespace: "managed-cluster", ClusterID: "323a00cd-428a-49fb-80ab-201d2a5d3050"}, monitor.ManagedClusterInfo[0], "Test Add ManagedCluster (MangedClusterInfo): local-cluster")
+	assert.Equal(t, map[string]bool{"323a00cd-428a-49fb-80ab-201d2a5d3050": true}, monitor.ClusterNeedsCCX, "Test Add ManagedCluster (ClusterNeedsCCX): local-cluster")
+
+}
+
+func Test_addCluster_nonOpenshift(t *testing.T) {
+	monitor := NewClusterMonitor()
+	monitor.ManagedClusterInfo = []types.ManagedClusterInfo{}
+	monitor.ClusterNeedsCCX = map[string]bool{}
+	managedCluster := clusterv1.ManagedCluster{}
+	unmarshalFile("managed-cluster-nonopenshift.json", &managedCluster, t)
+	monitor.addCluster(&managedCluster)
+
+	assert.Equal(t, types.ManagedClusterInfo{Namespace: "managed-cluster", ClusterID: "local-cluster-non-openshift"}, monitor.ManagedClusterInfo[0], "Test Add ManagedCluster: local-cluster-non-openshift")
+	assert.Equal(t, map[string]bool{"local-cluster-non-openshift": false}, monitor.ClusterNeedsCCX, "Test Add ManagedCluster (ClusterNeedsCCX): local-cluster-non-openshift")
 
 }
 
 func Test_updateCluster(t *testing.T) {
 	monitor := NewClusterMonitor()
 	monitor.ManagedClusterInfo = []types.ManagedClusterInfo{{Namespace: "managed-cluster", ClusterID: "123a00cd-428a-49fb-80ab-201d2a5d3050"}}
+	monitor.ClusterNeedsCCX = map[string]bool{"123a00cd-428a-49fb-80ab-201d2a5d3050": true}
 	managedCluster := clusterv1.ManagedCluster{}
 	unmarshalFile("managed-cluster.json", &managedCluster, t)
 
 	monitor.updateCluster(&managedCluster)
 
 	assert.Equal(t, types.ManagedClusterInfo{Namespace: "managed-cluster", ClusterID: "323a00cd-428a-49fb-80ab-201d2a5d3050"}, monitor.ManagedClusterInfo[0], "Test Add ManagedCluster: local-cluster")
+	assert.Equal(t, map[string]bool{"323a00cd-428a-49fb-80ab-201d2a5d3050": true}, monitor.ClusterNeedsCCX, "Test Update ManagedCluster (ClusterNeedsCCX): local-cluster")
+
+}
+
+func Test_updateCluster_nonOpenshift(t *testing.T) {
+	monitor := NewClusterMonitor()
+	monitor.ManagedClusterInfo = []types.ManagedClusterInfo{{Namespace: "managed-cluster", ClusterID: "test-cluster-non-openshift"}}
+	monitor.ClusterNeedsCCX = map[string]bool{"test-cluster-non-openshift": false}
+	managedCluster := clusterv1.ManagedCluster{}
+	unmarshalFile("managed-cluster-nonopenshift.json", &managedCluster, t)
+
+	monitor.updateCluster(&managedCluster)
+
+	assert.Equal(t, types.ManagedClusterInfo{Namespace: "managed-cluster", ClusterID: "local-cluster-non-openshift"}, monitor.ManagedClusterInfo[0], "Test Update ManagedCluster: local-cluster-non-openshift")
+	assert.Equal(t, map[string]bool{"local-cluster-non-openshift": false}, monitor.ClusterNeedsCCX, "Test Update ManagedCluster (ClusterNeedsCCX): local-cluster-non-openshift")
 
 }
 
 func Test_deleteCluster(t *testing.T) {
 	monitor := NewClusterMonitor()
 	monitor.ManagedClusterInfo = []types.ManagedClusterInfo{{Namespace: "managed-cluster", ClusterID: "323a00cd-428a-49fb-80ab-201d2a5d3050"}}
+	monitor.ClusterNeedsCCX = map[string]bool{"323a00cd-428a-49fb-80ab-201d2a5d3050": true}
 
 	managedCluster := clusterv1.ManagedCluster{}
 	unmarshalFile("managed-cluster.json", &managedCluster, t)
 
 	monitor.deleteCluster(&managedCluster)
 
-	assert.Equal(t, []types.ManagedClusterInfo{}, monitor.ManagedClusterInfo, "Test Delete ManagedCluster: lmanaged-cluster")
+	assert.Equal(t, []types.ManagedClusterInfo{}, monitor.ManagedClusterInfo, "Test Delete ManagedCluster: managed-cluster")
+	assert.Equal(t, map[string]bool{}, monitor.ClusterNeedsCCX, "Test Delete ManagedCluster: managed-cluster (ClusterNeedsCCX)")
+
+}
+
+func Test_deleteCluster_nonOpenshift(t *testing.T) {
+	monitor := NewClusterMonitor()
+	monitor.ManagedClusterInfo = []types.ManagedClusterInfo{{Namespace: "managed-cluster", ClusterID: "local-cluster-non-openshift"}}
+	monitor.ClusterNeedsCCX = map[string]bool{"local-cluster-non-openshift": false}
+
+	managedCluster := clusterv1.ManagedCluster{}
+	unmarshalFile("managed-cluster-nonopenshift.json", &managedCluster, t)
+
+	monitor.deleteCluster(&managedCluster)
+
+	assert.Equal(t, []types.ManagedClusterInfo{}, monitor.ManagedClusterInfo, "Test Delete ManagedCluster: local-cluster-non-openshift")
+	assert.Equal(t, map[string]bool{}, monitor.ClusterNeedsCCX, "Test Delete ManagedCluster: local-cluster-non-openshift (ClusterNeedsCCX)")
 
 }
 

--- a/test-data/managed-cluster-nonopenshift.json
+++ b/test-data/managed-cluster-nonopenshift.json
@@ -1,0 +1,174 @@
+{
+    "apiVersion": "cluster.open-cluster-management.io/v1",
+    "kind": "ManagedCluster",
+    "metadata": {
+       "selfLink": "/apis/cluster.open-cluster-management.io/v1/managedclusters/local-cluster",
+       "resourceVersion": "278609",
+       "name": "managed-cluster",
+       "uid": "c4e95b98-7258-4efe-ad33-ba16cedef75d",
+       "creationTimestamp": "2021-03-22T13:38:12Z",
+       "generation": 1,
+       "managedFields": [
+          {
+             "apiVersion": "cluster.open-cluster-management.io/v1",
+             "fieldsType": "FieldsV1",
+             "fieldsV1": {
+                "f:metadata": {
+                   "f:labels": {
+                      ".": {},
+                      "f:installer.name": {},
+                      "f:installer.namespace": {},
+                      "f:local-cluster": {}
+                   }
+                },
+                "f:spec": {
+                   ".": {},
+                   "f:hubAcceptsClient": {}
+                }
+             },
+             "manager": "multiclusterhub-operator",
+             "operation": "Update",
+             "time": "2021-03-22T13:38:12Z"
+          },
+          {
+             "apiVersion": "cluster.open-cluster-management.io/v1",
+             "fieldsType": "FieldsV1",
+             "fieldsV1": {
+                "f:metadata": {
+                   "f:labels": {
+                      "f:name": {}
+                   }
+                }
+             },
+             "manager": "rcm-controller",
+             "operation": "Update",
+             "time": "2021-03-22T13:38:12Z"
+          },
+          {
+             "apiVersion": "cluster.open-cluster-management.io/v1",
+             "fieldsType": "FieldsV1",
+             "fieldsV1": {
+                "f:metadata": {
+                   "f:finalizers": {}
+                }
+             },
+             "manager": "endpoint-operator",
+             "operation": "Update",
+             "time": "2021-03-22T13:38:15Z"
+          },
+          {
+             "apiVersion": "cluster.open-cluster-management.io/v1",
+             "fieldsType": "FieldsV1",
+             "fieldsV1": {
+                "f:metadata": {
+                   "f:labels": {
+                      "f:cloud": {},
+                      "f:clusterID": {},
+                      "f:vendor": {}
+                   }
+                }
+             },
+             "manager": "controller",
+             "operation": "Update",
+             "time": "2021-03-22T13:42:02Z"
+          },
+          {
+             "apiVersion": "cluster.open-cluster-management.io/v1",
+             "fieldsType": "FieldsV1",
+             "fieldsV1": {
+                "f:status": {
+                   ".": {},
+                   "f:allocatable": {
+                      ".": {},
+                      "f:cpu": {},
+                      "f:memory": {}
+                   },
+                   "f:capacity": {
+                      ".": {},
+                      "f:cpu": {},
+                      "f:memory": {}
+                   },
+                   "f:conditions": {},
+                   "f:version": {
+                      ".": {},
+                      "f:kubernetes": {}
+                   }
+                }
+             },
+             "manager": "registration",
+             "operation": "Update",
+             "time": "2021-03-22T13:42:04Z"
+          }
+       ],
+       "finalizers": [
+          "managedcluster-import-controller.open-cluster-management.io/cleanup",
+          "cluster.open-cluster-management.io/api-resource-cleanup",
+          "open-cluster-management.io/managedclusterrole",
+          "managedclusterinfo.finalizers.open-cluster-management.io",
+          "agent.open-cluster-management.io/klusterletaddonconfig-cleanup"
+       ],
+       "labels": {
+          "cloud": "Amazon",
+          "local-cluster": "true",
+          "name": "local-cluster-non-openshift"
+       }
+    },
+    "spec": {
+       "hubAcceptsClient": true,
+       "leaseDurationSeconds": 60
+    },
+    "status": {
+       "allocatable": {
+          "cpu": "21",
+          "memory": "89449Mi"
+       },
+       "capacity": {
+          "cpu": "24",
+          "memory": "96193Mi"
+       },
+       "clusterClaims": [
+          {
+             "name": "id.k8s.io",
+             "value": "local-cluster-non-openshift"
+          },
+          {
+             "name": "kubeversion.open-cluster-management.io",
+             "value": "v1.19.0+d59ce34"
+          },
+          {
+             "name": "platform.open-cluster-management.io",
+             "value": "AWS"
+          },
+          {
+             "name": "region.open-cluster-management.io",
+             "value": "us-east-1"
+          }
+       ],
+       "conditions": [
+          {
+             "lastTransitionTime": "2021-03-22T13:38:12Z",
+             "message": "Accepted by hub cluster admin",
+             "reason": "HubClusterAdminAccepted",
+             "status": "True",
+             "type": "HubAcceptedManagedCluster"
+          },
+          {
+             "lastTransitionTime": "2021-03-22T13:38:34Z",
+             "message": "Managed cluster is available",
+             "reason": "ManagedClusterAvailable",
+             "status": "True",
+             "type": "ManagedClusterConditionAvailable"
+          },
+          {
+             "lastTransitionTime": "2021-03-22T13:38:34Z",
+             "message": "Managed cluster joined",
+             "reason": "ManagedClusterJoined",
+             "status": "True",
+             "type": "ManagedClusterJoined"
+          }
+       ],
+       "version": {
+          "kubernetes": "v1.19.0+d59ce34"
+       }
+    }
+}


### PR DESCRIPTION
Signed-off-by: Will Kutler <wkutler@redhat.com>

**Related Issue:**  https://github.com/stolostron/backlog/issues/19407

### Description of changes

processes GRC violations on all clusters rather than just openshift. This was already added as a PR for 2.4