### PR TITLE
fix ccx loop breaking on non-ccx clusters

### DIFF
--- a/pkg/retriever/reportretriever.go
+++ b/pkg/retriever/reportretriever.go
@@ -161,7 +161,7 @@ func (r *Retriever) RetrieveCCXReport(
 		cluster := <-input
 		// If the cluster id is empty do nothing
 		if cluster.Namespace == "" || cluster.ClusterID == "" {
-			return
+			continue
 		}
 
 		if !clusterNeedsCCX(cluster, clusterCCXMap) {
@@ -169,7 +169,7 @@ func (r *Retriever) RetrieveCCXReport(
 				ClusterInfo: cluster,
 				Reports:     types.Reports{},
 			}
-			return
+			continue
 		}
 
 		glog.Infof("RetrieveCCXReport for cluster %s", cluster.Namespace)


### PR DESCRIPTION
Signed-off-by: Will Kutler <wkutler@redhat.com>

**Related Issue:**  https://bugzilla.redhat.com/show_bug.cgi?id=2073508

### Description of changes
fixes ccx loop breaking when processing a cluster that does not need ccx

