### PR TITLE
 added cluster if its not added by add event

### DIFF
--- a/pkg/monitor/clustermonitor.go
+++ b/pkg/monitor/clustermonitor.go
@@ -179,6 +179,7 @@ func (m *Monitor) processCluster(obj interface{}, handlerType string) {
 
 func (m *Monitor) addCluster(managedCluster *clusterv1.ManagedCluster) {
 	glog.V(2).Info("Processing Cluster Addition.")
+	glog.V(2).Infof("Currently mangaging %d clusters.", len(m.ManagedClusterInfo))
 	// We add the local cluster during Initialization.Using the method GetLocalCluster
 	if managedCluster.GetName() == localClusterName {
 		return
@@ -186,6 +187,7 @@ func (m *Monitor) addCluster(managedCluster *clusterv1.ManagedCluster) {
 	clusterVendor, version, clusterID := GetClusterClaimInfo(managedCluster)
 	if clusterID == "" {
 		//cluster not imported properly, do not process
+		glog.V(2).Info("Empty Cluster Id - Skipping Cluster Addition.")
 		return
 	}
 	glog.Infof("Adding %s to all cluster list", managedCluster.GetName())
@@ -195,7 +197,7 @@ func (m *Monitor) addCluster(managedCluster *clusterv1.ManagedCluster) {
 		ClusterID: clusterID,
 		Namespace: managedCluster.GetName(),
 	})
-
+	glog.V(2).Infof("Currently mangaging %d clusters.", len(m.ManagedClusterInfo))
 	// We only get Insights for OpenShift clusters versioned 4.x or greater.
 	if clusterVendor == "OpenShift" && version >= 4 {
 		glog.Infof("Adding %s to Insights cluster list", managedCluster.GetName())
@@ -208,7 +210,9 @@ func (m *Monitor) addCluster(managedCluster *clusterv1.ManagedCluster) {
 // Removes a ManagedCluster resource from ManagedClusterInfo list
 func (m *Monitor) updateCluster(managedCluster *clusterv1.ManagedCluster) {
 	glog.V(2).Info("Processing Cluster Update.")
-
+	glog.V(2).Infof("Currently mangaging %d clusters.", len(m.ManagedClusterInfo))
+	lock.Lock()
+	defer lock.Unlock()
 	clusterToUpdate := managedCluster.GetName()
 	if clusterToUpdate == "local-cluster" {
 		// We get local-clsuter ID from clusterversion resource.
@@ -224,9 +228,8 @@ func (m *Monitor) updateCluster(managedCluster *clusterv1.ManagedCluster) {
 	if found && clusterID != m.ManagedClusterInfo[clusterIdx].ClusterID {
 		// If the cluster ID has changed update it - otherwise do nothing.
 		glog.Infof("Updating %s from Insights cluster list", clusterToUpdate)
-		lock.Lock()
-		defer lock.Unlock()
 		if oldCluster, ok := m.ClusterNeedsCCX[m.ManagedClusterInfo[clusterIdx].ClusterID]; ok {
+			glog.Infof("old cluster %s ", oldCluster)
 			m.ClusterNeedsCCX[clusterID] = oldCluster
 			delete(m.ClusterNeedsCCX, m.ManagedClusterInfo[clusterIdx].ClusterID)
 			m.ManagedClusterInfo[clusterIdx] = types.ManagedClusterInfo{
@@ -238,17 +241,26 @@ func (m *Monitor) updateCluster(managedCluster *clusterv1.ManagedCluster) {
 	}
 
 	// Case to add a ManagedCluster to cluster list after it has been upgraded to version >= 4.X
-	if !found && clusterVendor == "OpenShift" && version >= 4 {
-		glog.Infof("Adding %s to Insights cluster list - Cluster was upgraded", managedCluster.GetName())
-		lock.Lock()
-		defer lock.Unlock()
-		m.ClusterNeedsCCX[clusterID] = true
+	// Or Cluster was missed during Add event
+	if !found && clusterID != "" {
+		glog.Infof("Adding %s to to all cluster list,missed from Add ", managedCluster.GetName())
+		m.ManagedClusterInfo = append(m.ManagedClusterInfo, types.ManagedClusterInfo{
+			ClusterID: clusterID,
+			Namespace: clusterToUpdate,
+		})
+		if clusterVendor == "OpenShift" && version >= 4 {
+			glog.Infof("Adding %s to Insights cluster list", managedCluster.GetName())
+			m.ClusterNeedsCCX[clusterID] = true
+		} else {
+			m.ClusterNeedsCCX[clusterID] = false
+		}
 	}
 }
 
 // Removes a ManagedCluster resource from ManagedClusterInfo list
 func (m *Monitor) deleteCluster(managedCluster *clusterv1.ManagedCluster) {
 	glog.V(2).Info("Processing Cluster Delete.")
+	glog.V(2).Infof("Currently mangaging %d clusters.", len(m.ManagedClusterInfo))
 	lock.Lock()
 	defer lock.Unlock()
 	clusterToDelete := managedCluster.GetName()
@@ -259,6 +271,7 @@ func (m *Monitor) deleteCluster(managedCluster *clusterv1.ManagedCluster) {
 			m.ManagedClusterInfo = append(m.ManagedClusterInfo[:clusterIdx], m.ManagedClusterInfo[clusterIdx+1:]...)
 		}
 	}
+	glog.V(2).Infof("Currently mangaging %d clusters.", len(m.ManagedClusterInfo))
 }
 
 // AddLocalCluster - adds local cluster to Clusters list
@@ -314,5 +327,6 @@ func (m *Monitor) GetLocalCluster() string {
 func (m *Monitor) GetManagedClusterInfo() []types.ManagedClusterInfo {
 	lock.Lock()
 	defer lock.Unlock()
+	glog.V(2).Infof("Total managed clusters in processing list  %d .", len(m.ManagedClusterInfo))
 	return m.ManagedClusterInfo
 }

--- a/pkg/monitor/clustermonitor.go
+++ b/pkg/monitor/clustermonitor.go
@@ -229,7 +229,7 @@ func (m *Monitor) updateCluster(managedCluster *clusterv1.ManagedCluster) {
 		// If the cluster ID has changed update it - otherwise do nothing.
 		glog.Infof("Updating %s from Insights cluster list", clusterToUpdate)
 		if oldCluster, ok := m.ClusterNeedsCCX[m.ManagedClusterInfo[clusterIdx].ClusterID]; ok {
-			glog.Infof("old cluster %s ", oldCluster)
+			glog.Infof("old cluster %t ", oldCluster)
 			m.ClusterNeedsCCX[clusterID] = oldCluster
 			delete(m.ClusterNeedsCCX, m.ManagedClusterInfo[clusterIdx].ClusterID)
 			m.ManagedClusterInfo[clusterIdx] = types.ManagedClusterInfo{


### PR DESCRIPTION
Signed-off-by: xavier dharmaiyan <xavier@redhat.com>

**Related Issue:**  open-cluster-management/backlog#<ISSUE_NUMBER>

### Description of changes

Fix for https://bugzilla.redhat.com/show_bug.cgi?id=2075440

@willkutler  it appears that a timing issue , that when the add even happens the cluster id is empty . That causes to miss the cluster when it joins the hub. Made a fix , if we get a managedcluster CR update and we dont know about it , add to the list. 