### PR TITLE
Provide a clear log message when a cluster can't be handled

### DIFF
--- a/pkg/monitor/clustermonitor.go
+++ b/pkg/monitor/clustermonitor.go
@@ -23,6 +23,8 @@ import (
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 )
 
+const IDClusterClaim = "id.k8s.io"
+
 var lock = sync.RWMutex{}
 var localClusterName = "local-cluster"
 
@@ -53,7 +55,7 @@ func GetClusterClaimInfo(managedCluster *clusterv1.ManagedCluster) (string, int6
 		if claimInfo.Name == "id.openshift.io" {
 			clusterID = claimInfo.Value
 		}
-		if clusterID == "" && claimInfo.Name == "id.k8s.io" {
+		if clusterID == "" && claimInfo.Name == IDClusterClaim {
 			clusterID = claimInfo.Value
 		}
 	}
@@ -187,7 +189,9 @@ func (m *Monitor) addCluster(managedCluster *clusterv1.ManagedCluster) {
 	clusterVendor, version, clusterID := GetClusterClaimInfo(managedCluster)
 	if clusterID == "" {
 		//cluster not imported properly, do not process
-		glog.V(2).Info("Empty Cluster Id - Skipping Cluster Addition.")
+		glog.Infof(
+			"Skipping the cluster %s because its %s cluster claim is not set", managedCluster.GetName(), IDClusterClaim,
+		)
 		return
 	}
 	lock.Lock()


### PR DESCRIPTION
When a cluster is missing its id.k8s.io cluster claim, it can't be handled. There was no indication that this was happening except a debug log message that is not displayed by default. This commit makes the log message clearer and changes it to a regular info log.

Relates:
https://issues.redhat.com/browse/ACM-2625