### PR TITLE
Check severity on template, not root policy

### DIFF
--- a/pkg/processor/reportprocessor.go
+++ b/pkg/processor/reportprocessor.go
@@ -320,7 +320,16 @@ func getSevFromTemplate(plc unstructured.Unstructured, name string) string {
 			return severity
 
 			// If this isn't an OCM policy, check for a severity annotation
-		} else if severityAnnotation, ok := plc.GetAnnotations()["policy.open-cluster-management.io/severity"]; ok {
+		} else {
+			severityAnnotation, severityFound, err := unstructured.NestedString(
+				objDef, "metadata", "annotations", "policy.open-cluster-management.io/severity",
+			)
+			if !severityFound || err != nil {
+				glog.V(1).Infof(
+					"error parsing objectDefinition severity annotation as a string for policy %s, template %d: %s", plcName, idx, err)
+				break
+			}
+
 			return severityAnnotation
 		}
 	}


### PR DESCRIPTION
ref: https://issues.redhat.com/browse/ACM-6350

Followup to:
- #143 

The previous PR was checking for the annotation on the root policy, which would set the severity on every policy template. The intention was to be able to set the severity on each policy template.