### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for insights-client-acm-214

### DIFF
--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -20,9 +20,10 @@ USER ${USER_UID}
 ENTRYPOINT ["/bin/main"]
 
 LABEL com.redhat.component="acm-insights-client-container" \
+      cpe="cpe:/a:redhat:acm:2.14::el9" \
       description="Insights client service" \
       maintainer="acm-contact@redhat.com" \
-      name="insights-client" \
+      name="rhacm2/insights-client-rhel9" \
       org.label-schema.license="Red Hat Advanced Cluster Management for Kubernetes EULA" \
       org.label-schema.schema-version="1.0" \
       summary="Insights client service" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
