### PR TITLE
[CCXDEV-16275] Set default CCX_SERVER to public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ Uses Red Hat Connected Customer Experience (CCX) to provide health check insight
 ### Environment Variables
 Control the behavior of this service with these environment variables.
 
-Name             | Required | Default Value                           | Description
----------------- | -------- | --------------------------------------- | -----------
-HTTP_TIMEOUT     | no       | 180000                                  | 3 minute timeout to process a single requests
-CCX_SERVER       | no       | http://localhost:8080/api/v1/clusters   | CCX server url (prod will use: `https://cloud.redhat.com/api/insights-results-aggregator/v2`)
-CCX_TOKEN        | no       | Not set                                 | If not set client will get cloud.openshift.com token from secret `openshift-config`
-POLL_INTERVAL    | no       | 30                                      | 30 minute default polling interval cloud.redhat.com
-REQUEST_INTERVAL | no       | 1                                       | 1 second Interval between 2 consecutive Insights requests
-CACERT           | no       | Not set                                 | Used for dev & test ONLY
+Name             | Required | Default Value                                                 | Description
+---------------- | -------- | ------------------------------------------------------------- | -----------
+HTTP_TIMEOUT     | no       | 180000                                                        | 3 minute timeout to process a single requests
+CCX_SERVER       | no       | https://cloud.redhat.com/api/insights-results-aggregator/v2   | CCX server public API
+CCX_TOKEN        | no       | Not set                                                       | If not set client will get cloud.openshift.com token from secret `openshift-config`
+POLL_INTERVAL    | no       | 30                                                            | 30 minute default polling interval cloud.redhat.com
+REQUEST_INTERVAL | no       | 1                                                             | 1 second Interval between 2 consecutive Insights requests
+CACERT           | no       | Not set                                                       | Used for dev & test ONLY
 
 Rebuild: 2022-09-16

--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ Uses Red Hat Connected Customer Experience (CCX) to provide health check insight
 ### Environment Variables
 Control the behavior of this service with these environment variables.
 
-Name             | Required | Default Value                                                 | Description
----------------- | -------- | ------------------------------------------------------------- | -----------
-HTTP_TIMEOUT     | no       | 180000                                                        | 3 minute timeout to process a single requests
-CCX_SERVER       | no       | https://cloud.redhat.com/api/insights-results-aggregator/v2   | CCX server public API
-CCX_TOKEN        | no       | Not set                                                       | If not set client will get cloud.openshift.com token from secret `openshift-config`
-POLL_INTERVAL    | no       | 30                                                            | 30 minute default polling interval cloud.redhat.com
-REQUEST_INTERVAL | no       | 1                                                             | 1 second Interval between 2 consecutive Insights requests
-CACERT           | no       | Not set                                                       | Used for dev & test ONLY
+Name             | Required | Default Value                                                   | Description
+---------------- | -------- | --------------------------------------------------------------- | -----------
+HTTP_TIMEOUT     | no       | 180000                                                          | 3 minute timeout to process a single requests
+CCX_SERVER       | no       | https://console.redhat.com/api/insights-results-aggregator/v2   | CCX server public API
+CCX_TOKEN        | no       | Not set                                                         | If not set client will get cloud.openshift.com token from secret `openshift-config`
+POLL_INTERVAL    | no       | 30                                                              | 30 minute default polling interval cloud.redhat.com
+REQUEST_INTERVAL | no       | 1                                                               | 1 second Interval between 2 consecutive Insights requests
+CACERT           | no       | Not set                                                         | Used for dev & test ONLY
 
 Rebuild: 2022-09-16

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -14,7 +14,7 @@ import (
 const (
 	DEFAULT_SERVICE_PORT     = ":3030"
 	DEFAULT_HTTP_TIMEOUT     = 180000                                  // 3 minutes HTTP Timeout
-	DEFAULT_CCX_SERVER       = "http://localhost:8080/api/v1/clusters" // For local use only
+	DEFAULT_CCX_SERVER       = "https://console.redhat.com/api/insights-results-aggregator/v2"
 	DEFAULT_POLL_INTERVAL    = 30                                      // 30mins default polling interval cloud.redhat.com
 	DEFAULT_REQUEST_INTERVAL = 1                                       // 1 second Interval between 2 consecutive requests
 	DEFAULT_POD_NAMESPACE    = "kube-system"                           // Namespace of insights-client pod

--- a/test-data/e2e/insights-chart/templates/insights-deployment.yaml
+++ b/test-data/e2e/insights-chart/templates/insights-deployment.yaml
@@ -86,9 +86,7 @@ spec:
         - name: USE_MOCK 
           value: "false"
         - name: CCX_TOKEN
-          value: "{{ INSIGHTS_CLIENT_CCX_TOKEN }}"  
-        - name: CCX_SERVER
-          value: "https://console.redhat.com/api/insights-results-aggregator/v2"
+          value: "{{ INSIGHTS_CLIENT_CCX_TOKEN }}"
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:


### PR DESCRIPTION
### Related Issue
https://redhat.atlassian.net/browse/CCXDEV-16275

### Description of changes
insights-client CCX_SERVER should be set to public API (https://cloud.redhat.com/api/insights-results-aggregator/v2) by default. 
CCX_SERVER is possible to update by env variable in deployment YAML in production.
This change helps the CCX team's move to use on-prem API.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reformatted Environment Variables table in README for consistent spacing and updated the CCX_SERVER entry to reflect the production API default.

* **Chores**
  * Changed the default CCX_SERVER to the production endpoint.
  * Removed the hardcoded CCX_SERVER from the deployment template and normalized related environment variable formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->