### PR TITLE
Add Dockerfile.art for ART/Brew build migration

### DIFF
--- a/Dockerfile.art
+++ b/Dockerfile.art
@@ -1,0 +1,34 @@
+# Copyright (c) 2024 Red Hat, Inc.
+# Copyright Contributors to the Open Cluster Management project
+
+FROM registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:v1.25.8 AS builder
+
+WORKDIR /go/src/github.com/stolostron/insights-client
+COPY . .
+RUN go mod vendor
+RUN CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime go build -trimpath -o main main.go
+
+FROM registry-proxy.engineering.redhat.com/ubi9/ubi-minimal:latest
+
+COPY --from=builder /go/src/github.com/stolostron/insights-client/main /bin/main
+
+ENV VCS_REF="$VCS_REF" \
+    USER_UID=1001
+
+EXPOSE 3030
+USER ${USER_UID}
+ENTRYPOINT ["/bin/main"]
+
+ARG ACM_VERSION=${ACM_VERSION}
+
+LABEL com.redhat.component="acm-insights-client-container" \
+      description="Insights client service" \
+      maintainer="acm-contact@redhat.com" \
+      name="rhacm2/insights-client-rhel9" \
+      org.label-schema.license="Red Hat Advanced Cluster Management for Kubernetes EULA" \
+      org.label-schema.schema-version="1.0" \
+      summary="Insights client service" \
+      io.k8s.display-name="Insights client" \
+      io.k8s.description="Insights client service" \
+      io.openshift.tags="data,images" \
+      cpe="cpe:/a:redhat:acm:${ACM_VERSION}::el9"


### PR DESCRIPTION
HYPBLD-847: ACM 2.16: Create Dockerfile.art + ocp-build-data config
https://redhat.atlassian.net/browse/HYPBLD-847

Create the build configuration required for ART to build ACM 2.16 components.

Dockerfile.art files (50 repos):                                                                     
- Create Dockerfile.art in each ACM repo on release-2.16 branch                                      
- Use existing Dockerfile.rhtap as starting point                                                    
- Change registry to registry-proxy.engineering.redhat.com
- Add FIPS flags (GOEXPERIMENT=strictfipsruntime, CGO_ENABLED=1)                                     
Note: multiclusterhub-operator uses brew.registry — needs manual FROM line conversion              

Signed-off-by: Brian Smith (briansmi@redhat.com)