### PR TITLE
Experiment: Test Red Hat Hardened core-runtime Image (release-acm-212)

### DIFF
--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -8,7 +8,7 @@ COPY . .
 RUN go mod vendor
 RUN CGO_ENABLED=1 go build -trimpath -o main main.go
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+FROM registry.access.redhat.com/hi/core-runtime:latest-openssl-fips
 
 COPY --from=builder /go/src/github.com/stolostron/insights-client/main /bin/main
 


### PR DESCRIPTION
## Purpose
This is an **experimental PR** against the inactive **release-acm-212** application to test Red Hat's hardened images.

## Changes
- Switch runtime base image from `ubi9/ubi-minimal`
- To: `registry.access.redhat.com/hi/core-runtime:latest-openssl-fips`
- **Modified file:** `Dockerfile.rhtap` (ONLY file changed)

## Details
**Component:** insights-client
**Target Release:** release-2.12 (inactive)
**Hardened Image:** core-runtime with FIPS-enabled OpenSSL

### Why This Component?
- Clean Dockerfile - only copies binaries
- No package manager usage detected
- Good candidate for hardened image compatibility testing

## Testing
- Target: Inactive release-acm-212 Konflux application
- Goal: Validate Konflux build success with hardened images
- Focus: FIPS compliance, runtime compatibility
- Reference: https://images.redhat.com/

## Notes
- This is for experimentation only
- Not intended for merge to active releases
- Monitoring Konflux build pipeline for compatibility
- Part of systematic testing across ACM 2.12 components
- **Only the Dockerfile was modified** - no other changes

/hold
/cc @gparvin