### PR TITLE
ACM-37376 - Update Go to 1.26

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: builder
   namespace: stolostron
-  tag: go1.25-linux
+  tag: go1.26-linux

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) 2021 Red Hat, Inc.
 # Copyright Contributors to the Open Cluster Management project
 
-FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS builder
 
 WORKDIR /go/src/github.com/stolostron/insights-client
 COPY . .

--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Red Hat, Inc.
 # Copyright Contributors to the Open Cluster Management project
 
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 AS builder
 
 WORKDIR /go/src/github.com/stolostron/insights-client
 COPY . .

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ build-linux:
 .PHONY: lint
 lint:
 	GOPATH=$(go env GOPATH)
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "${GOPATH}/bin" v2.4.0
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "${GOPATH}/bin" v2.9.0
 	CGO_ENABLED=1 GOGC=25 golangci-lint run --timeout=3m
 	
 run:

--- a/Makefile.prow
+++ b/Makefile.prow
@@ -5,7 +5,7 @@
 .PHONY: lint
 lint:
 	GOPATH=$(go env GOPATH)
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "${GOPATH}/bin" v2.4.0
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "${GOPATH}/bin" v2.9.0
 	CGO_ENABLED=1 GOGC=25 golangci-lint run --timeout=3m
 		
 .PHONY: unit-test

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stolostron/insights-client
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/go-logr/logr v1.4.2 // indirect


### PR DESCRIPTION
- go.mod: 1.25.0 → 1.26.0
- Dockerfile: go1.25-linux → go1.26-linux
- Dockerfile.rhtap: rhel_9_1.25 → rhel_9_1.26
- .ci-operator.yaml: go1.25-linux → go1.26-linux
- Makefile, Makefile.prow: golangci-lint v2.4.0 → v2.9.0

<!-- Include the Jira issue in the title, example: 'ACM-0000 Implement feature XYZ' -->

### Related Issue
<!-- Update Jira link -->
https://issues.redhat.com/browse/ACM-37376

### Description of changes
- Added ...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project to build with Go 1.26.
  * Refreshed build environments to use Go 1.26-based images.
  * Updated linting tooling to golangci-lint v2.9.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->